### PR TITLE
fix: deprecated checkout actions

### DIFF
--- a/.github/workflows/buildTest.yml
+++ b/.github/workflows/buildTest.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 

--- a/.github/workflows/kibotVerify.yml
+++ b/.github/workflows/kibotVerify.yml
@@ -25,17 +25,17 @@ jobs:
     container:
       image: setsoft/kicad_auto:ki8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: run kibot
         run: | 
           kibot -c ${{env.config}} -e ${{env.schema}} -b ${{env.board}} -d ${{env.dir}} -s run_drc -v -i
-          
+
   DRC:
     runs-on: ubuntu-latest
     container:
       image: setsoft/kicad_auto:ki8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: run kibot
         run: | 
           kibot -c ${{env.config}} -e ${{env.schema}} -b ${{env.board}} -d ${{env.dir}} -s run_erc -v -i
@@ -47,7 +47,7 @@ jobs:
     container:
       image: setsoft/kicad_auto:ki8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: run kibot
         run: | 
           kibot -c ${{env.config}} -e ${{env.schema}} -b ${{env.board}} -d ${{env.dir}} -s run_erc,run_drc -v \
@@ -61,7 +61,7 @@ jobs:
             ${{env.dir}}/docs/**
             !${{env.dir}}/**/*.ogv
             !${{env.dir}}/**/*.log
-                      
+
   # images
   render:
     runs-on: ubuntu-latest
@@ -69,7 +69,7 @@ jobs:
     container:
       image: setsoft/kicad_auto:ki8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: run kibot
         run: | 
           kibot -c ${{env.config}} -e ${{env.schema}} -b ${{env.board}} -d ${{env.dir}} -s run_erc,run_drc -v \
@@ -83,14 +83,14 @@ jobs:
             ${{env.dir}}/img/**
             !${{env.dir}}/**/*.ogv
             !${{env.dir}}/**/*.log
- 
+
   render3d:
     runs-on: ubuntu-latest
     needs: [DRC]
     container:
       image: setsoft/kicad_auto:ki8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: run kibot
         run: | 
           kibot -c ${{env.config}} -e ${{env.schema}} -b ${{env.board}} -d ${{env.dir}} -s run_erc,run_drc -v \
@@ -115,7 +115,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ssh-key: ${{secrets.KIBOT}}
       - uses: actions/download-artifact@v4

--- a/.github/workflows/pushDockerRepos.yml
+++ b/.github/workflows/pushDockerRepos.yml
@@ -31,7 +31,7 @@ jobs:
           df -h
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -93,7 +93,7 @@ jobs:
           df -h
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -150,7 +150,7 @@ jobs:
     if: ${{ github.repository == 'mniedermaier/CybICS' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,7 +27,7 @@ jobs:
       run: sudo apt-get install -y nmap
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,7 @@ jobs:
         submodules: recursive
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Secret Scanning


### PR DESCRIPTION
GitHub shows the following:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-python@v5. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

I bumped the actions accordingly, let's see if the tests still run